### PR TITLE
Add noFutureProofEnums option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ yarn relay-enum-generator [options]
 - name: Name of your generated file
 - path: Path where your file will be generated in
 - schema: Path of schema to read from. Default value is read from relay.config file
+- noFutureProofEnums: This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future.
 
 ## Acknowledgments
 

--- a/src/InterospectionQueryToEnums.ts
+++ b/src/InterospectionQueryToEnums.ts
@@ -1,21 +1,30 @@
 import { IntrospectionQuery } from 'graphql';
 import { isIntrospectionEnumType } from './helpers';
 
+export interface Options {
+  noFutureProofEnums?: boolean;
+}
+
 export function interospectionQueryToEnums(
   interospectionQuery: IntrospectionQuery | undefined | null,
+  options: Options = {},
 ) {
   if (!interospectionQuery) {
     return;
   }
 
+  const { noFutureProofEnums } = options;
+
   return interospectionQuery.__schema.types
     .filter(isIntrospectionEnumType)
     .filter(({ name }) => !name.startsWith('_'))
-    .map(e => {
-      const { name, enumValues } = e;
-      const values = enumValues
-        .map(enumValue => enumValue.name)
-        .concat('%future added value');
+    .map(introspectionEnumType => {
+      const { name, enumValues } = introspectionEnumType;
+      const values = enumValues.map(enumValue => enumValue.name);
+
+      if (!noFutureProofEnums) {
+        values.push('%future added value');
+      }
 
       return `export type ${name} =\n  | '` + values.join("'\n  | '") + "' \n";
     })

--- a/src/bin/relay-enum-generator.ts
+++ b/src/bin/relay-enum-generator.ts
@@ -5,9 +5,8 @@ import { Config, write } from '../write';
 import { parseSchema } from '../parseSchema';
 
 const relayConfig = require('relay-config').loadConfig();
-const defaultSchemaPath = relayConfig['schema'];
-const defaultPath = './src/__generated__';
-const defaultName = 'enums.ts';
+const schema = relayConfig['schema'];
+const noFutureProofEnums = relayConfig['noFutureProofEnums'];
 
 async function main(config: Config) {
   await parseSchema(config.schema).then(result => {
@@ -24,21 +23,30 @@ const options: Record<keyof Config, yargs.Options> = {
     type: 'string',
     string: true,
     array: false,
-    default: defaultName,
+    default: 'enums.ts',
   },
   path: {
     describe: 'Path where your file will be generated in',
     type: 'string',
     string: true,
     array: false,
-    default: defaultPath,
+    default: './src/__generated__',
   },
   schema: {
-    describe: 'Path of schema to read from',
+    describe: 'Path to schema.graphql',
     type: 'string',
     string: true,
     array: false,
-    default: defaultSchemaPath,
+    default: schema,
+  },
+  noFutureProofEnums: {
+    describe:
+      'This option controls whether or not a catch-all entry is added to enum type definitions ' +
+      'for values that may be added in the future.',
+    type: 'boolean',
+    boolean: true,
+    array: false,
+    default: noFutureProofEnums,
   },
 };
 

--- a/src/write.ts
+++ b/src/write.ts
@@ -9,13 +9,16 @@ export interface Config {
   name: string;
   path: string;
   schema: string;
+  noFutureProofEnums: boolean;
 }
 
 export function write(
   result: ExecutionResult<IntrospectionQuery>,
   config: Config,
 ) {
-  const enums = interospectionQueryToEnums(result.data);
+  const enums = interospectionQueryToEnums(result.data, {
+    noFutureProofEnums: config.noFutureProofEnums,
+  });
   if (!fs.existsSync(config.path)) {
     fs.mkdirSync(config.path);
   }


### PR DESCRIPTION
This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future. 
For more information see this [Link](https://github.com/facebook/relay/blob/master/packages/relay-compiler/bin/RelayCompilerBin.js#L101)