### PR TITLE
add .gql extension to schema parser

### DIFF
--- a/src/parseSchema.ts
+++ b/src/parseSchema.ts
@@ -11,8 +11,8 @@ import {
 
 /**
  *
- * Parses schema file basedd on its type.
- * supported GraphQL schema types: .graphql
+ * Parses schema file based on its type.
+ * supported GraphQL schema types: .graphql, .gql
  *
  * @param schemaPath full path to GraphQL schema file
  */
@@ -25,6 +25,7 @@ export async function parseSchema(
 
   switch (schemaExtname) {
     case '.graphql':
+    case '.gql':
       const graphqlSchema = buildSchema(schema);
       const introspectionQuery = getIntrospectionQuery();
       result = await graphql<IntrospectionQuery>(


### PR DESCRIPTION
GraphQL files with `.gql` extension are typically the same as `.graphql`, `parseSchema` should handle and treat as equal